### PR TITLE
Solve permission denied error when building jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Please ensure that all system requirements, including a compatible version of `B
 3. Build the standalone `jar`:
 
    ```bash
+   chmod +x ./gradlew
    ./gradlew shadowJar
    ```
 


### PR DESCRIPTION
Solve permission denied error when building jar by doing `chmod +x` before building